### PR TITLE
원문 업데이트 golang/go@56c9b51

### DIFF
--- a/Declarations and scope/method_declarations.md
+++ b/Declarations and scope/method_declarations.md
@@ -3,11 +3,11 @@
 A method is a [function](/Declarations%20and%20scope/function_declarations.html) with a *receiver*. A method declaration binds an identifier, the *method name*, to a method, and associates the method with the receiver's *base type*.
 
 <pre>
-<a id="MethodDecl">MethodDecl</a>   = "func" <a href="#Receiver">Receiver</a> <a href="/Types/interface_types.html#MethodName">MethodName</a> ( <a href="/Declarations%20and%20scope/function_declarations.html#Function">Function</a> | <a href="/Types/function_types.html#Signature">Signature</a> ) .
-<a id="Receiver">Receiver</a>     = <a href="/Types/function_types.html#Parameters">Parameters</a> .
+<a id="MethodDecl">MethodDecl</a> = "func" <a href="#Receiver">Receiver</a> <a href="/Types/interface_types.html#MethodName">MethodName</a> ( <a href="/Declarations%20and%20scope/function_declarations.html#Function">Function</a> | <a href="/Types/function_types.html#Signature">Signature</a> ) .
+<a id="Receiver">Receiver</a>   = <a href="/Types/function_types.html#Parameters">Parameters</a> .
 </pre>
 
-The receiver is specified via an extra parameter section preceding the method name. That parameter section must declare a single non-variadic parameter, the receiver. Its type must be of the form T or *T (possibly using parentheses) where T is a type name. The type denoted by T is called the receiver *base type*; it must not be a pointer or interface type and it must be declared in the same package as the method. The method is said to be bound to the base type and the method name is visible only within [selectors](/Expressions/selectors.html) for type T or *T.
+The receiver is specified via an extra parameter section preceding the method name. That parameter section must declare a single non-variadic parameter, the receiver. Its type must be of the form T or *T (possibly using parentheses) where T is a type name. The type denoted by T is called the receiver *base type*; it must not be a pointer or interface type and it must be [declared](/Declarations%20and%20scope/type_declarations.html) in the same package as the method. The method is said to be bound to the base type and the method name is visible only within [selectors](/Expressions/selectors.html) for type T or *T.
 
 A non-[blank](/Declarations%20and%20scope/blank_identifier.html) receiver identifier must be [unique](/Declarations%20and%20scope/uniqueness_of_identifiers.html) in the method signature. If the receiver's value is not referenced inside the body of the method, its identifier may be omitted in the declaration. The same applies in general to parameters of functions and methods.
 

--- a/Declarations and scope/type_declarations.md
+++ b/Declarations and scope/type_declarations.md
@@ -1,18 +1,40 @@
 # Type declarations
 
-A type declaration binds an identifier, the *type name*, to a new type that has the same [underlying type](/Types/) as an existing type, and operations defined for the existing type are also defined for the new type. The new type is [different](/Properties%20of%20types%20and%20values/type_identity.html) from the existing type.
+A type declaration binds an identifier, the *type name*, to a <a href="#Types">type</a>.
+Type declarations come in two forms: Alias declarations and type definitions.
 
 <pre>
-<a id="TypeDecl">TypeDecl</a>     = "type" ( <a href="#TypeSpec">TypeSpec</a> | "(" { (<a href="#TypeSpec">TypeSpec</a> ";" } ")" ) .
-<a id="TypeSpec">TypeSpec</a>     = <a href="/Lexical%20elements/identifiers.html#identifier">identifier</a> <a href="/Types/#Type">Type</a> .
+<a id="TypeDecl">TypeDecl</a> = "type" ( <a href="#TypeSpec">TypeSpec</a> | "(" { (<a href="#TypeSpec">TypeSpec</a> ";" } ")" ) .
+<a id="TypeSpec">TypeSpec</a> = <a href="#AliasDecl">AliasDecl</a> | <a href="#TypeDef">TypeDef</a> .
 </pre>
+
+## Alias declarations
+
+An alias declaration binds an identifier to the given type.
+
+<pre>
+<a id="AliasDecl">AliasDecl</a> = <a href="/Lexical%20elements/identifiers.html#identifier">identifier</a> "=" <a href="#Type">Type</a> .
+</pre>
+
+Within the [scope](/Declarations%20and%20scope/) of the identifier, it serves as an *alias* for the type.
+
+## Type definitions
+
+A type definition binds an identifier to a newly created type with the same [underlying type](/Types/) and operations as the given type.
+
+<pre>
+<a id="TypeDef">TypeDef</a> = <a href="/Lexical%20elements/identifiers.html#identifier">identifier</a> <a href="/Types/#Type">Type</a> .
+</pre>
+
+The new type is called a *defined type*.
+It is [different](Properties%20of%20types%20and%20values/type_identity.html) from any other type, including the type it is created from.
 
 ```
 type IntArray [16]int
 
 type (
-	Point struct{ x, y float64 }
-	Polar Point
+	Point struct{ x, y float64 }  // Point and struct{ x, y float64 } are different types
+	polar Point                   // polar and Point denote different types
 )
 
 type TreeNode struct {
@@ -26,8 +48,8 @@ type Block interface {
 	Decrypt(src, dst []byte)
 }
 ```
-
-The declared type does not inherit any [methods](/Declarations%20and%20scope/method_declarations.html) bound to the existing type, but the [method set](/Types/method_sets.html) of an interface type or of elements of a composite type remains unchanged:
+A defined type may have [methods](/Declarations%20and%20scope/method_declarations.html) associated with it.
+It does not inherit any methods bound to the given type, but the [method set](/Types/method_sets.html) of an interface type or of elements of a composite type remains unchanged:
 
 ```
 // A Mutex is a data type with two methods, Lock and Unlock.
@@ -52,7 +74,7 @@ type PrintableMutex struct {
 type MyBlock Block
 ```
 
-A type declaration may be used to define a different boolean, numeric, or string type and attach methods to it:
+Type definitions may be used to define different boolean, numeric, or string types and associate methods with them:
 
 ```
 type TimeZone int

--- a/Declarations and scope/variable_declarations.md
+++ b/Declarations and scope/variable_declarations.md
@@ -1,6 +1,6 @@
 # Variable declarations
 
-A variable declaration creates one or more variables, binds corresponding identifiers to them, and gives each a type and an initial value.
+A variable declaration creates one or more [variables](/Variables/), binds corresponding identifiers to them, and gives each a type and an initial value.
 
 <pre>
 <a id="VarDecl">VarDecl</a>     = "var" ( <a href="#VarSpec">VarSpec</a> | "(" { <a href="#VarSpec">VarSpec</a> ";" } ")" ) .

--- a/Properties of types and values/assignability.md
+++ b/Properties of types and values/assignability.md
@@ -4,8 +4,8 @@
 A value x is assignable to a [variable](/Variables/) of type T ("x is assignable to T") in any of these cases:
 
   * x's type is identical to T.
-  * x's type V and T have identical [underlying types](/Types/) and at least one of V or T is not a [named type](/Types/).
+  * x's type V and T have identical [underlying types](/Types/) and at least one of V or T is not a [defined](/Type_definitions/) type.
   * T is an interface type and x [implements](/Types/interface_types.html) T.
-  * x is a bidirectional channel value, T is a channel type, x's type V and T have identical element types, and at least one of V or T is not a named type.
+  * x is a bidirectional channel value, T is a channel type, x's type V and T have identical element types, and at least one of V or T is not a defined type.
   * x is the predeclared identifier nil and T is a pointer, function, slice, map, channel, or interface type.
   * x is an untyped [constant](/Constants/) representable by a value of type T.

--- a/Properties of types and values/type_identity.md
+++ b/Properties of types and values/type_identity.md
@@ -2,7 +2,10 @@
 
 Two types are either identical or different.
 
-Two [named types](/Types/) are identical if their type names originate in the same [TypeSpec](/Declarations%20and%20scope/type_declarations.html). A named and an [unnamed type](/Types/) are always different. Two unnamed types are identical if the corresponding type literals are identical, that is, if they have the same literal structure and corresponding components have identical types. In detail:
+A <a href="#Type_definitions">defined type</a> is always different from any other type.
+Otherwise, two types are identical if their <a href="#Types">underlying</a> type literals are
+structurally equivalent; that is, they have the same literal structure and corresponding
+components have identical types. In detail:
 
   * Two array types are identical if they have identical element types and the same array length.
   * Two slice types are identical if they have identical element types.
@@ -17,22 +20,38 @@ Given the declarations
 
 ```
 type (
-	T0 []string
-	T1 []string
-	T2 struct{ a, b int }
-	T3 struct{ a, c int }
-	T4 func(int, float64) *T0
-	T5 func(x int, y float64) *[]string
+	A0 []string
+	A1 = A0
+	A2 = struct{ a, b int }
+	A3 = int
+	A4 = func(A3, float64) *A0
+	A5 = func(x int, _ float64) *[]string
 )
+
+type (
+  B0 A0
+  B1 []string
+  B2 struct{ a, b int }
+  B3 struct{ a, c int }
+  B4 func(int, float64) *B0
+  B5 func(x int, y float64) *A1
+)
+
+type	C0 = B0
 ```
 
 these types are identical:
 
 ```
-T0 and T0
+A0, A1, and []string
+A2 and struct{ a, b int }
+A3 and int
+A4, func(int, float64) *[]string, and A5
+
+B0, B0, and C0
 []int and []int
 struct{ a, b *T5 } and struct{ a, b *T5 }
-func(x int, y float64) *[]string and func(int, float64) (result *[]string)
+func(x int, y float64) *[]string, func(int, float64) (result *[]string), and A5
 ```
 
-T0 and T1 are different because they are named types with distinct declarations; `func(int, float64) *T0` and `func(x int, y float64) *[]string` are different because T0 is different from `[]string`.
+B0 and B1 are different because they are new types new types created by distinct <a href="#Type_definitions">type definitions</a>; `func(int, float64) *B0` and `func(x int, y float64) *[]string` are different because B0 is different from `[]string`.

--- a/Types/README.md
+++ b/Types/README.md
@@ -1,6 +1,7 @@
 # Types
 
-A type determines the set of values and operations specific to values of that type. Types may be *named* or *unnamed*. Named types are specified by a (possibly [qualified](/Expressions/qualified_identifiers.html)) [type name](/Declarations%20and%20scope/type_declarations.html); unnamed types are specified using a *type literal*, which composes a new type from existing types.
+A type determines the set of values together with operations and methods specific to those values.\
+A type may be denoted by a *type name*, if it has one, or specified using a *type literal*, which composes a type from existing types.
 
 <pre>
 <a id="Type">Type</a>      = <a href="#TypeName">TypeName</a> | <a href="#TypeLit">TypeLit</a> | "(" <a href="#Type">Type</a> ")" .
@@ -8,16 +9,25 @@ A type determines the set of values and operations specific to values of that ty
 <a id="TypeLit">TypeLit</a>   = <a href="/Types/array_types.html#ArrayType">ArrayType</a> | <a href="/Types/struct_types.html#StructType">StructType</a> | <a href="/Types/pointer_types.html#PointerType">PointerType</a> | <a href="/Types/function_types.html#FunctionType">FunctionType</a> | <a href="/Types/interface_types.html#InterfaceType">InterfaceType</a> | <a href="/Types/slice_types.html#SliceType">SliceType</a> | <a href="/Types/map_types.html#MapType">MapType</a> | <a href="/Types/channel_types.html#ChannelType">ChannelType</a> .
 </pre>
 
-Named instances of the boolean, numeric, and string types are [predeclared](/Declarations%20and%20scope/predeclared_identifiers.html). *Composite types*—array, struct, pointer, function, interface, slice, map, and channel types—may be constructed using type literals.
+Named instances of the boolean, numeric, and string types are [predeclared](/Declarations%20and%20scope/predeclared_identifiers.html). 
+Other named types are introduced with [type declarations](/Declarations%20and%20scope/type_declarations.html).
+*Composite types*—array, struct, pointer, function, interface, slice, map, and channel types—may be constructed using type literals.
 
 
 Each type T has an *underlying type*: If T is one of the predeclared boolean, numeric, or string types, or a type literal, the corresponding underlying type is T itself. Otherwise, T's underlying type is the underlying type of the type to which T refers in its [type declaration](/Declarations%20and%20scope/type_declarations.html).
 
 ```
-   type T1 string
-   type T2 T1
-   type T3 []T1
-   type T4 T3
+type (
+    A1 = string
+    A2 = A1
+)
+
+type (
+    B1 string
+    B2 B1
+    B3 []B1
+    B4 B3
+)
 ```
 
-The underlying type of string, T1, and T2 is string. The underlying type of []T1, T3, and T4 is []T1.
+The underlying type of string, A1, A2, B1 and B2 is string. The underlying type of []B1, B3, and B4 is []B1.


### PR DESCRIPTION
[golang/go@56c9b5](https://github.com/golang/go/commit/56c9b51b937cca7d3db517add96bd9517bbffb80#diff-94792ed6b8d17736ee79af0ca532d6fe)

최하위 항목에 대한 링크를 어떻게 해야 할지 몰라 남겨두었습니다.

어떻게 해야할 지 알려주시면 수정하도록 하겠습니다.

```
[declared](/Declarations%20and%20scope/type_declarations.html
```

로 되어있는데, 이 항목은 실제로는 Declarations and scope/type_declarations 하위 항목인 Type definitions 항목에 링크되어야 합니다.