### PR TITLE
fix String to string, string to 문자열

### DIFF
--- a/Types/string_types.md
+++ b/Types/string_types.md
@@ -1,6 +1,4 @@
-# String types
-
-# [String 타입(String types)](#string-types)
+# [string 타입(String types)](#string-types)
 
 * Go 버전: 1.9
 * 원문 : [String types](https://golang.org/ref/spec#String_types)
@@ -8,8 +6,8 @@
 
 A *string type* represents the set of string values. A string value is a (possibly empty) sequence of bytes. Strings are immutable: once created, it is impossible to change the contents of a string. The predeclared string type is `string`.
 
-*String 타입*은 String 값들의 집합을 나타낸다. 하나의 String 값은(비어있을 수 있음) 바이트들의 연속 이다. 모든 String은 불변이다: 한 번 생성된 String의 내용을 변경하는 것은 불가능하다. 미리 선언된 String의 타입은 `string`이다.
+*string 타입*은 문자열 값들의 집합을 표현한다. 문자열 값은(비어있을 수 있음) 바이트들의 연속이다. 모든 문자열은 불변(immutable)이다: 한 번 생성된 문자열의 내용을 변경하는 것은 불가능하다. 문자열을 다루기 위해 미리 선언된 타입은 `string`이다.
 
 The length of a string s (its size in bytes) can be discovered using the built-in function [len](/Built-in%20functions/length_and_capacity.html). The length is a compile-time constant if the string is a constant. A string's bytes can be accessed by integer [indices](/Expressions/index_expressions.html) 0 through `len(s)-1`. It is illegal to take the address of such an element; if `s[i]` is the i'th byte of a string, `&s[i]` is invalid.
 
-어떠한 String s의 길이(바이트 사이즈)는 내장함수인 [len](/Built-in%20functions/length_and_capacity.html)를 이용해서 구할 수 있다. 만약 String이 상수일 경우 그 길이는 컴파일시 계산된 상수 값이다. 한 String의 바이트는 0부터 `len(s)-1`까지의 정수 [인덱스들](/Expressions/index_expressions.html)로 접근 가능하다. 그러나 String의 요소 하나의 주소를 가져올 수 없다; 만약 `s[i]`이 어떠한 String의 i번째 바이트라면, `&s[i]`는 사용할 수 없다.
+문자열 `s`의 길이(바이트 단위)는 내장함수인 [len](/Built-in%20functions/length_and_capacity.html)을 이용해서 구할 수 있다. 만약 문자열이 상수일 경우 그 길이는 컴파일시 계산된 상수 값이다. 0부터 `len(s)-1`까지의 정수 [인덱스](/Expressions/index_expressions.html)를 이용해 문자열의 바이트에 접근할 수 있지만, 인덱스에 해당하는 요소의 주소를 가져올 수는 없다; 즉, `s[i]`이 어떠한 문자열의 i번째 바이트라면, `&s[i]`는 사용할 수 없다.


### PR DESCRIPTION
- String type 은 string type 으로 수정
- string 이 타입을 의미하는 것이 아니라 `문자열`을 의미하는 경우 `문자열`로 표현
- 기타 번역 문장 개선
 