### PR TITLE
expresison 번역 용어 통일

### DIFF
--- a/Constants/README.md
+++ b/Constants/README.md
@@ -10,11 +10,11 @@ There are *boolean constants*, *rune constants*, *integer constants*, *floating-
 
 A constant value is represented by a [rune](/Lexical%20elements/rune_literals.html), [integer](/Lexical%20elements/integer_literals.html), [floating-point](/Lexical%20elements/floating-point_literals.html), [imaginary](/Lexical%20elements/imaginary_literals.html), or [string literal](/Lexical%20elements/string_literals.html), an identifier denoting a constant, a [constant expression](/Expressions/constant_expressions.html), a [conversion](/Expressions/conversions.html) with a result that is a constant, or the result value of some built-in functions such as `unsafe.Sizeof` applied to any value, `cap` or `len` applied to [some expressions](/Built-in%20functions/length_and_capacity.html), `real` and `imag` applied to a complex constant and `complex` applied to numeric constants. The boolean truth values are represented by the predeclared constants `true` and `false`. The predeclared identifier [iota](/Declarations%20and%20scope/iota.html) denotes an integer constant.
 
-상수 값은 [룬 문자](/Lexical%20elements/rune_literals.html), [정수](/Lexical%20elements/integer_literals.html), [부동소수점]((/Lexical%20elements/floating-point_literals.html)), [허수](/Lexical%20elements/imaginary_literals.html), [문자열 리터럴](/Lexical%20elements/string_literals.html), 상수 식별자, [상수 표현식](/Expressions/constant_expressions.html), [변환된 상수](/Expressions/conversions.html) 결과값 또는 `unsafe.Sizeof` 같은 몇몇 내장 함수들의 결과값이 적용된 값, `cap` 또는 `len`이 적용된 몇몇 표현식들, `real`와 `imag`가 적용된 복소수 상수와 `complex`가 적용된 수치 상수로 표현된다. boolean 값은 미리 선언되어 있는 `true` 와 `false` 값으로 표현된다. 미리 선언된 식별자 [iota](/Declarations%20and%20scope/iota.html)는 정수형 상수값을 의미한다.
+상수 값은 [룬 문자](/Lexical%20elements/rune_literals.html), [정수](/Lexical%20elements/integer_literals.html), [부동소수점]((/Lexical%20elements/floating-point_literals.html)), [허수](/Lexical%20elements/imaginary_literals.html), [문자열 리터럴](/Lexical%20elements/string_literals.html), 상수 식별자, [상수 식](/Expressions/constant_expressions.html), [변환된 상수](/Expressions/conversions.html) 결과값 또는 `unsafe.Sizeof` 같은 몇몇 내장 함수들의 결과값이 적용된 값, `cap` 또는 `len`이 적용된 [몇 가지 식](/Built-in%20functions/length_and_capacity.html), `real`와 `imag`가 적용된 복소수 상수와 `complex`가 적용된 수치 상수로 표현된다. boolean 값은 미리 선언되어 있는 `true` 와 `false` 값으로 표현된다. 미리 선언된 식별자 [iota](/Declarations%20and%20scope/iota.html)는 정수형 상수값을 의미한다.
 
 In general, complex constants are a form of [constant expression](/Expressions/constant_expressions.html) and are discussed in that section.
 
-일반적으로 복소수 상수들은 [상수 표현식](/Expressions/constant_expressions.html)이며 이는 현재 섹션에서 설명될 것이다.
+일반적으로 복소수 상수들은 [상수 식](/Expressions/constant_expressions.html)이며 이는 현재 섹션에서 설명될 것이다.
 
 Numeric constants represent exact values of arbitrary precision and do not overflow. Consequently, there are no constants denoting the IEEE-754 negative zero, infinity, and not-a-number values.
 
@@ -22,11 +22,11 @@ Numeric constants represent exact values of arbitrary precision and do not overf
 
 Constants may be [typed](/Types/) or *untyped*. Literal constants, `true`, `false`, `iota`, and certain [constant expressions](/Expressions/constant_expressions.html) containing only untyped constant operands are untyped.
 
-상수는 [지정된 타입(typed)](/Types/)이거나 *비지정된 타입(untyped)*일수 있다. 상수 리터럴, `true`, `false`, `iota` 들과 오직 비지정 타입 피연산자 상수들만 포함하는 특정 [상수 표현식](/Expressions/constant_expressions.html)들은 비지정 타입이다.
+상수는 [지정된 타입(typed)](/Types/)이거나 *비지정된 타입(untyped)*일수 있다. 상수 리터럴, `true`, `false`, `iota` 들과 오직 비지정 타입 피연산자 상수들만 포함하는 특정 [상수 식](/Expressions/constant_expressions.html)들은 비지정 타입이다.
 
 A constant may be given a type explicitly by a [constant declaration](/Declarations%20and%20scope/constant_declarations.html) or [conversion](/Expressions/conversions.html), or implicitly when used in a [variable declaration](/Declarations%20and%20scope/variable_declarations.html) or an [assignment](/Statements/assignments.html) or as an operand in an [expression](/Expressions/). It is an error if the constant value cannot be represented as a value of the respective type. For instance, 3.0 can be given any integer or any floating-point type, while 2147483648.0 (equal to 1<<31) can be given the types `float32`, `float64`, or `uint32` but not `int32` or `string`.
 
-어떤 [상수의 선언](/Declarations%20and%20scope/constant_declarations.html) 또는 [변환](/Expressions/conversions.html)에 의해서, 또는 암시적으로 어떤 변수에 [할당](/Statements/assignments.html) 또는 [선언](/Declarations%20and%20scope/variable_declarations.html) 할때, 아니면 어떤 [표현식](/Expressions/)의 피연산자로서 사용될때 타입은 명시적으로 주어질수 있다. 만약 상수값이 각각의 타입의 값으로 표현되지 못한다면 에러가 발생한다. 예를 들어, 3.0은 어떤 정수형 또는 아무 부동 소수점 타입으로 지정될 수 있으며, 2147483648.0( 1 << 31와 동일 )에는 `float32`, `float64` 또는 `uint32`와 같은 타입이 주어질 수 있지만 `int32` 또는 `string`은 2147483648.0의 타입이 되지 못한다.
+어떤 [상수의 선언](/Declarations%20and%20scope/constant_declarations.html) 또는 [변환](/Expressions/conversions.html)에 의해서, 또는 암시적으로 어떤 변수에 [할당](/Statements/assignments.html) 또는 [선언](/Declarations%20and%20scope/variable_declarations.html) 할때, 아니면 어떤 [식](/Expressions/)의 피연산자로서 사용될때 타입은 명시적으로 주어질수 있다. 만약 상수값이 각각의 타입의 값으로 표현되지 못한다면 에러가 발생한다. 예를 들어, 3.0은 어떤 정수형 또는 아무 부동 소수점 타입으로 지정될 수 있으며, 2147483648.0( 1 << 31와 동일 )에는 `float32`, `float64` 또는 `uint32`와 같은 타입이 주어질 수 있지만 `int32` 또는 `string`은 2147483648.0의 타입이 되지 못한다.
 
 An untyped constant has a *default type* which is the type to which the constant is implicitly converted in contexts where a typed value is required, for instance, in a [short variable declaration](/Declarations%20and%20scope/short_variable_declarations.html) such as i := 0 where there is no explicit type. The default type of an untyped constant is `bool`, `rune`, `int`, `float64`, `complex128` or `string` respectively, depending on whether it is a boolean, rune, integer, floating-point, complex, or string constant.
 
@@ -50,4 +50,4 @@ Implementation restriction: Although numeric constants have arbitrary precision 
 
 These requirements apply both to literal constants and to the result of evaluating constant expressions.
 
-이 요구사항들은 리터럴 상수와 상수 표현식의 평가 결과 모두에게 적용된다.
+이 요구사항들은 리터럴 상수와 상수 식의 평가 결과 모두에게 적용된다.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -37,6 +37,9 @@ blank 식별자.
 ## equality operators
 동등 연산자.
 
+## expression
+식. 예를 들어, index expression의 번역은 인덱스 식
+
 ## function body
 함수 본문.
 
@@ -45,9 +48,6 @@ blank 식별자.
 
 ## illegal
 허용안됨. 문장에서 사용될 경우 “Go 문법에서는 … 허용하지 않는다 ” 로 번역 
-
-## index expressions
-인덱스 표현.
 
 ## key type
 키 타입.

--- a/Program initialization and execution/package_initialization.md
+++ b/Program initialization and execution/package_initialization.md
@@ -10,7 +10,7 @@ Within a package, package-level variables are initialized in *declaration order*
 
 More precisely, a package-level variable is considered *ready for initialization* if it is not yet initialized and either has no [initialization expression](/Declarations and scope/variable_declarations.html) or its initialization expression has no dependencies on uninitialized variables. Initialization proceeds by repeatedly initializing the next package-level variable that is earliest in declaration order and ready for initialization, until there are no variables ready for initialization.
 
-더 정확하게 설명하자면, 패키지 레벨의 변수는 아직 초기화가 되지 않은 상태에서 만약 [초기화 표현식](/Declarations and scope/variable_declarations.html)이 없거나, 있다해도 다른 초기화되지 않은 변수에 대한 의존도가 없다면 *초기화 준비가 된 상태*로 간주한다. 패키지 레벨 변수의 초기화는 더이상 초기화할 준비가 된 변수가 존재하지 않을 때까지, 선언문에 먼저 나타나는 순서대로 반복해서 진행된다.
+더 정확하게 설명하자면, 패키지 레벨의 변수는 아직 초기화가 되지 않은 상태에서 만약 [초기화 식](/Declarations and scope/variable_declarations.html)이 없거나, 있다해도 다른 초기화되지 않은 변수에 대한 의존도가 없다면 *초기화 준비가 된 상태*로 간주한다. 패키지 레벨 변수의 초기화는 더이상 초기화할 준비가 된 변수가 존재하지 않을 때까지, 선언문에 먼저 나타나는 순서대로 반복해서 진행된다.
 
 If any variables are still uninitialized when this process ends, those variables are part of one or more initialization cycles, and the program is not valid.
 
@@ -26,11 +26,11 @@ Dependency analysis does not rely on the actual values of the variables, only on
   * A reference to a method `m` is a [method value](/Expressions/method_values.html) or [method expression](/Expressions/method_expressions.html) of the form `t.m`, where the (static) type of `t` is not an interface type, and the method `m` is in the [method set](/Types/method_sets.html) of `t`. It is immaterial whether the resulting function value `t.m` is invoked.
   * A variable, function, or method `x` depends on a variable `y` if `x`'s initialization expression or body (for functions and methods) contains a reference to `y` or to a function or method that depends on `y`.
 
-의존성에 대한 분석은 변수들의 실제값들에 의지하지 않고, 단지 소스내 변수들을 언급하는 어휘적 *레퍼런스*(lexical *references*)에 의해 전이적으로 (transitively) 분석된다. 예를 들어, 만약에 변수 x의 초기화 표현식이 함수를 언급하고 함수의 몸통이 변수 y를 언급한다면, x는 y에 의존하는 것이다. 구체적으로:
+의존성에 대한 분석은 변수들의 실제값들에 의지하지 않고, 단지 소스내 변수들을 언급하는 어휘적 *레퍼런스*(lexical *references*)에 의해 전이적으로 (transitively) 분석된다. 예를 들어, 만약에 변수 x의 초기화 식이 함수를 언급하고 함수의 몸통이 변수 y를 언급한다면, x는 y에 의존하는 것이다. 구체적으로:
 
  * 변수나 함수에 대한 레퍼런스는 변수나 함수를 표시하는 식별자이다.
- * 메서드 `m`에 대한 레퍼런스는 [메서드 값](/Expressions/method_values.html)이거나 `t.m` 형태의 [메서드 표현](/Expressions/method_expressions.html)으로, `t`의 (정적) 타입은 인터페이스 타입이 아니고, 메서드 `m`은 `t`의 [메서드 집합](/Types/method_sets.html)에 존재한다. 결과적인 함수 값 `t.m`이 호출되었는지 여부는 중요하지 않다.
- * 변수, 함수, 혹은 메서드 `x`가 변수 `y`에 의존적이라 함은 `x`의 초기화 표현식이나 (함수들이나 메서드들의) 몸통이 `y`에 대해 레퍼런스를 가지고 있던지 `y`에 의존적인 함수나 메서드에 레퍼런스를 가지고 있는 경우다.
+ * 메서드 `m`에 대한 레퍼런스는 [메서드 값](/Expressions/method_values.html)이거나 `t.m` 형태의 [메서드 식](/Expressions/method_expressions.html)으로, `t`의 (정적) 타입은 인터페이스 타입이 아니고, 메서드 `m`은 `t`의 [메서드 집합](/Types/method_sets.html)에 존재한다. 결과적인 함수 값 `t.m`이 호출되었는지 여부는 중요하지 않다.
+ * 변수, 함수, 혹은 메서드 `x`가 변수 `y`에 의존적이라 함은 `x`의 초기화 식이나 (함수들이나 메서드들의) 몸통이 `y`에 대해 레퍼런스를 가지고 있던지 `y`에 의존적인 함수나 메서드에 레퍼런스를 가지고 있는 경우다.
 
 Dependency analysis is performed per package; only references referring to variables, functions, and methods declared in the current package are considered.
 

--- a/System considerations/package_unsafe.md
+++ b/System considerations/package_unsafe.md
@@ -41,7 +41,7 @@ The functions `Alignof` and `Sizeof` take an expression x of any type and return
 
 The function `Offsetof` takes a (possibly parenthesized) [selector](/Expressions/selectors.html) `s.f`, denoting a field `f` of the struct denoted by `s` or `*s`, and returns the field offset in bytes relative to the struct's address. If `f` is an [embedded field](/Types/struct_types.html), it must be reachable without pointer indirections through fields of the struct. For a struct `s` with field `f`:
 
-`Offsetof` 함수는 구조체인 `s`나 `*s`의 필드를 의미하는 `f`를 (괄호가 사용되었을 가능성이 있는) [선택자 표현(selector)](/Expressions/selectors.html)인 `s.f`로 받아서 구조체 주소에 상대적인 필드의 오프셋(offset)을 바이트 단위로 돌려준다. 만약 `f`가 [임베디드 필드(embedded field)](/Types/struct_types.html)일 경우, 구조체의 필드들을 통한 포인터 인디렉션(pointer indirection) 없이 접근할 수 있어야 한다. 구조체 `s`의 필드 `f`에 대해:
+`Offsetof` 함수는 구조체인 `s`나 `*s`의 필드를 의미하는 `f`를 (괄호가 사용되었을 가능성이 있는) [선택자(selector)](/Expressions/selectors.html)인 `s.f`로 받아서 구조체 주소에 상대적인 필드의 오프셋(offset)을 바이트 단위로 돌려준다. 만약 `f`가 [임베디드 필드(embedded field)](/Types/struct_types.html)일 경우, 구조체의 필드들을 통한 포인터 인디렉션(pointer indirection) 없이 접근할 수 있어야 한다. 구조체 `s`의 필드 `f`에 대해:
 
 ```
 uintptr(unsafe.Pointer(&s)) + unsafe.Offsetof(s.f) == uintptr(unsafe.Pointer(&s.f))
@@ -49,7 +49,7 @@ uintptr(unsafe.Pointer(&s)) + unsafe.Offsetof(s.f) == uintptr(unsafe.Pointer(&s.
 
 Computer architectures may require memory addresses to be *aligned*; that is, for addresses of a variable to be a multiple of a factor, the variable's type's *alignment*. The function `Alignof` takes an expression denoting a variable of any type and returns the alignment of the (type of the) variable in bytes. For a variable `x`:
 
-어떤 컴퓨터 아키텍쳐들은 메모리 주소의 *정렬(aligned)*을 요구할 수도 있다; 즉, 변수의 주소들은 변수 타입의 *얼라인먼트(alignment)*라는 인자의 배수이어야 한다. `Alignof` 함수는 어떤 타입의 변수를 의미하는 표현식을 받아서 (그 타입의) 변수의 얼라인먼트를 바이트 단위로 돌려준다. 변수 `x`의 예를 들자면:
+어떤 컴퓨터 아키텍쳐들은 메모리 주소의 *정렬(aligned)*을 요구할 수도 있다; 즉, 변수의 주소들은 변수 타입의 *얼라인먼트(alignment)*라는 인자의 배수이어야 한다. `Alignof` 함수는 어떤 타입의 변수를 의미하는 식을 받아서 (그 타입의) 변수의 얼라인먼트를 바이트 단위로 돌려준다. 변수 `x`의 예를 들자면:
 
 
 ```
@@ -58,4 +58,4 @@ uintptr(unsafe.Pointer(&x)) % unsafe.Alignof(x) == 0
 
 Calls to `Alignof`, `Offsetof`, and `Sizeof` are compile-time constant expressions of type `uintptr`.
 
-`Alignof`, `Offsetof`, 그리고 `Sizeof` 함수들에 대한 호출은 `uintptr` 타입의 컴파일 타임(compile-time) 상수 표현들이다.
+`Alignof`, `Offsetof`, 그리고 `Sizeof` 함수들에 대한 호출은 `uintptr` 타입의 컴파일 타임(compile-time) 상수 식이다.

--- a/Types/map_types.md
+++ b/Types/map_types.md
@@ -26,7 +26,7 @@ map[string]interface{}
 
 The number of map elements is called its length. For a map m, it can be discovered using the built-in function [len](/Built-in%20functions/length_and_capacity.html) and may change during execution. Elements may be added during execution using [assignments](/Statements/assignments.html) and retrieved with [index expressions](/Expressions/index_expressions.html); they may be removed with the [delete](/Built-in%20functions/deletion_of_map_elements.html) built-in function.
 
-map `m`에 대한 길이는 내장 함수인 [len](/Built-in%20functions/length_and_capacity.html)을 이용해 구할 수 있으며, 이 길이는 프로그램 실행 중 변경될 수 있다. 프로그램 실행 중 [할당(assignments)](/Statements/assignments.html)을 이용해 새로운 요소를 추가할 수 있으며, [인덱스 표현(index expressions)](/Expressions/index_expressions.html)을 이용해 요소에 접근할 수 있다; 내장 함수인 [`delete`](/Built-in%20functions/deletion_of_map_elements.html)를 사용해 요소를 삭제할 수도 있다.
+map `m`에 대한 길이는 내장 함수인 [len](/Built-in%20functions/length_and_capacity.html)을 이용해 구할 수 있으며, 이 길이는 프로그램 실행 중 변경될 수 있다. 프로그램 실행 중 [할당(assignments)](/Statements/assignments.html)을 이용해 새로운 요소를 추가할 수 있으며, [인덱스 식(index expressions)](/Expressions/index_expressions.html)을 이용해 요소에 접근할 수 있다; 내장 함수인 [`delete`](/Built-in%20functions/deletion_of_map_elements.html)를 사용해 요소를 삭제할 수도 있다.
 
 A new, empty map value is made using the built-in function [make](/Built-in%20functions/making_slices,_maps_and_channels.html), which takes the map type and an optional capacity hint as arguments:
 

--- a/Types/slice_types.md
+++ b/Types/slice_types.md
@@ -22,7 +22,7 @@ A slice, once initialized, is always associated with an underlying array that ho
 
 The array underlying a slice may extend past the end of the slice. The *capacity* is a measure of that extent: it is the sum of the length of the slice and the length of the array beyond the slice; a slice of length up to that capacity can be created by [slicing](/Expressions/slice_expressions.html) a new one from the original slice. The capacity of a slice a can be discovered using the built-in function [cap(a)](/Built-in%20functions/length_and_capacity.html).
 
-내재하는 array는 슬라이스의 끝을 넘어서도 계속될 수 있다. *수용력(capapcity)*은 그러한 범위에 대한 계량이다: 슬라이스의 길이와 슬라이스의 경계를 넘어서 있는 구역의 길이의 합이다; 수용력(capacity)과 같은 길이의 슬라이스는 원래의 슬라이스로 부터 [슬라이스 표현(slicing)](/Expressions/slice_expressions.html)을 사용해 새로운 슬라이스로 만들 수 있다. 슬라이스의 수용력(capacity)는 내장 함수 [cap(a)](/Built-in%20functions/length_and_capacity.html)를 가지고 산출할 수 있다.
+내재하는 array는 슬라이스의 끝을 넘어서도 계속될 수 있다. *수용력(capapcity)*은 그러한 범위에 대한 계량이다: 슬라이스의 길이와 슬라이스의 경계를 넘어서 있는 구역의 길이의 합이다; 수용력(capacity)과 같은 길이의 슬라이스는 원래의 슬라이스로 부터 [슬라이싱(slicing)](/Expressions/slice_expressions.html)을 사용해 새로운 슬라이스로 만들 수 있다. 슬라이스의 수용력(capacity)는 내장 함수 [cap(a)](/Built-in%20functions/length_and_capacity.html)를 가지고 산출할 수 있다.
 
 A new, initialized slice value for a given element type T is made using the built-in function [make](/Built-in%20functions/making_slices,_maps_and_channels.html), which takes a slice type and parameters specifying the length and optionally the capacity. A slice created with make always allocates a new, hidden array to which the returned slice value refers. That is, executing
 
@@ -34,7 +34,7 @@ make([]T, length, capacity)
 
 produces the same slice as allocating an array and [slicing](/Expressions/slice_expressions.html) it, so these two expressions are equivalent:
 
-array를 할당하고 [슬라이스 표현(slicing)](/Expressions/slice_expressions.html)으로 슬라이스를 만든 것과 같은 슬라이스를 생산하게 되어서, 다음의 두 표현식은 동일하다:
+array를 할당하고 [슬라이싱(slicing)](/Expressions/slice_expressions.html)으로 슬라이스를 만든 것과 같은 슬라이스를 생산하게 되어서, 다음의 두 표현식은 동일하다:
 
 ```
 make([]int, 50, 100)

--- a/Variables/README.md
+++ b/Variables/README.md
@@ -36,4 +36,4 @@ x = v              // x는 (*T)(nil)를 *T형 동적 타입으로 가진다
 
 A variable's value is retrieved by referring to the variable in an [expression](/Expressions/); it is the most recent value [assigned](/Statements/assignments.html) to the variable. If a variable has not yet been assigned a value, its value is the [zero value](/Program%20initialization%20and%20execution/the_zero_value.html) for its type.
 
-변수의 값은 [표현식](/Expressions/)에 있는 변수를 참조함으로서 검색된다. 이것은 가장 최근에 해당 변수에 [할당된](/Statements/assignments.html) 값이다. 만약 아직 값이 변수에 할당되어지지 않았다면 변수의 값은 해당 변수의 타입을 위해 [zero값](/Program%20initialization%20and%20execution/the_zero_value.html)이 된다.
+변수의 값은 [식](/Expressions/)에 있는 변수를 참조함으로서 검색된다. 이것은 가장 최근에 해당 변수에 [할당된](/Statements/assignments.html) 값이다. 만약 아직 값이 변수에 할당되어지지 않았다면 변수의 값은 해당 변수의 타입을 위해 [zero값](/Program%20initialization%20and%20execution/the_zero_value.html)이 된다.


### PR DESCRIPTION
### 체크리스트
- [x] [번역 가이드 라인](https://github.com/golangkorea/golang-spec#번역-가이드라인) 문서는 읽어보셨나요? 
- [x] 용어집에 추가할 번역 용어가 있나요? 있다면 [이슈 게시판](https://github.com/golangkorea/golang-spec/issues/105)에 코멘트를 남겨주세요.

### 설명
관련 기존 번역에서 expression을 번역한 부분 수정하여 번역 용어 `식` 으로 통일

### 참고사항(선택사항)
#154 